### PR TITLE
fix: chunked error on github runners this afternoon, avoid installing

### DIFF
--- a/src/.github/workflows/{% if github_actions and github_actions_ci_branches %}ci.yml{% endif %}.jinja
+++ b/src/.github/workflows/{% if github_actions and github_actions_ci_branches %}ci.yml{% endif %}.jinja
@@ -79,8 +79,6 @@ jobs:
 
       - name: Setup pipx
         run: |
-          python3 -m pip install --user pipx
-          pipx install docker-compose
           pipx install invoke
           pipx install pre-commit
           pipx ensurepath


### PR DESCRIPTION
## Description

Chunked error on GitHub runners this afternoon, avoid installing duplicates of programs already installed (pipx, docker-compose)

Fixes T7255

Associated risk level low

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

