### PR TITLE
fix: templated .gitignore is in the incorrect order, resulting in .vscode being ignored when not intended

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -15,12 +15,12 @@
 **.orig
 
 # User-specific or editor-specific development files and settings
+.vscode/*
 !/.vscode/*.jinja
 !/.vscode/extensions.json
 !/.vscode/launch.json
 !/.vscode/settings.json
 !/.vscode/tasks.json
-.vscode/*
 /odoo/custom/src/private/.vscode/*
 /.venv
 /doodba.*.code-workspace


### PR DESCRIPTION
## Description

Templated .gitignore is in the incorrect order, resulting in .vscode being ignored when not intended.

For further discussion.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

