### PR TITLE
fix: DB_VERSION went missing from the build options, resulting in pg_restore issues after pg 16

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -132,7 +132,7 @@ odoo_oci_image:
 postgres_version:
   default: "13"
   help: >-
-    Which PostgreSQL version do you want to deploy?
+    Which PostgreSQL version do you want to use? This should match production.
   choices:
     I will use an external PostgreSQL server: ""
     "9.6": "9.6"
@@ -141,6 +141,7 @@ postgres_version:
     "12": "12"
     "13": "13"
     "14": "14"
+    "15": "15",
 
 postgres_username:
   type: str

--- a/src/.github/workflows/{% if github_actions and github_actions_build_branches and odoo_oci_image %}build.yml{% endif %}.jinja
+++ b/src/.github/workflows/{% if github_actions and github_actions_build_branches and odoo_oci_image %}build.yml{% endif %}.jinja
@@ -56,5 +56,8 @@ jobs:
           push: true
           build-args: |
             ODOO_VERSION={% raw %}${{ env.ODOO_VERSION }}{% endraw %}
+            {%- if odoo_version >= 11 %}
+            DB_VERSION="{{ postgres_version or 'latest' }}"
+            {%- endif %}
           tags: {% raw %}${{ steps.meta.outputs.tags }}{% endraw %}
           labels: {% raw %}${{ steps.meta.outputs.labels }}{% endraw %}

--- a/src/common.yaml.jinja
+++ b/src/common.yaml.jinja
@@ -9,6 +9,9 @@ services:
     build:
       context: ./odoo
       args:
+        {%- if odoo_version >= 11 %}
+        DB_VERSION: "{{ postgres_version or 'latest' }}"
+        {%- endif %}
         ODOO_VERSION: "{{ macros.version_minor(odoo_version) }}"
         UID: "${UID:-1000}"
         GID: "${GID:-1000}"


### PR DESCRIPTION
## Description

DB_VERSION went missing from the build options, resulting in pg_restore issues after pg 16 released.

We will need to ensure that production and dev are aligned when we copier update.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

