### PR TITLE
fix: Locale C & btree index performance

### DIFF
--- a/src/common.yaml.jinja
+++ b/src/common.yaml.jinja
@@ -32,6 +32,13 @@ services:
     environment:
       POSTGRES_DB: postgres
       POSTGRES_USER: *dbuser
+      # Why locale C? PostgreSQL is "under-optimized" with the use of 
+      # LIKE queries using wildcards (LIKE 'foo%') in conjunction with btree
+      # indexes, when not using locale C.
+      # See:
+      #   - https://github.com/odoo/odoo/pull/25196#issuecomment-396683972
+      #   - https://www.postgresql.org/docs/16/indexes-types.html#INDEXES-TYPES-BTREE
+      POSTGRES_INITDB_ARGS: "--locale=C --encoding=UTF8"
       CONF_EXTRA: |
         work_mem = 512MB
     volumes:


### PR DESCRIPTION
## Description

Force the locale for new databases to "C".

Why? PostgreSQL is "under-optimized" with the use of  LIKE queries using wildcards (LIKE 'foo%') in conjunction with btree indexes, when not using locale C.

Whilst generally not an issue on a developer install, it does surface on larger databases, and it is a good place for us to document this.

See:
- https://github.com/odoo/odoo/pull/25196#issuecomment-396683972
- https://www.postgresql.org/docs/16/indexes-types.html#INDEXES-TYPES-BTREE

Associated risk level low

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Suggested UAT/Review Steps

If applicable please list any steps that the end user may require to verify or test the new behaviour.

