### PR TITLE
feat: pytest support from Kobi

### DIFF
--- a/src/odoo/custom/dependencies/pip.txt.jinja
+++ b/src/odoo/custom/dependencies/pip.txt.jinja
@@ -6,3 +6,4 @@ pathlib
 {% endif -%}
 inotify
 coverage
+pytest-odoo


### PR DESCRIPTION
## Description

Taking @kobfolson's original implementation and massaging it slightly to fit within the existing methods and functions.

- Allows `invoke test --pytest` or `invoke pytest`
- :warning: Coverage and pytest are not supported concurrently (yet)
- :warning: Debugpy is not supported concurrently (yet)

Associated risk level medium

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
