### PR TITLE
feat: fix invoke add-github-enterprise-repository

### DIFF
--- a/src/tasks_downstream.py
+++ b/src/tasks_downstream.py
@@ -673,7 +673,8 @@ def add_github_repository(
 
     with open(SRC_PATH / "addons.yaml", "r+") as f:
         addons = yaml.safe_load(f.read())
-        if f"{yaml_alias}" not in addons:
+        if not addons or f"{yaml_alias}" not in addons:
+            addons = addons or {}
             addons.update({f"{yaml_alias}": ["*"]})
 
             f.seek(0)


### PR DESCRIPTION
Calling the 'invoke add-github-enterprise-repository' in a new project which has no addons configured in its addons.yaml throws the NoneType error below

TypeError: argument of type 'NoneType' is not iterable

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Suggested UAT/Review Steps

If applicable please list any steps that the end user may require to verify or test the new behaviour.

