### PR TITLE
fix(tasks_downstream.py): If coverage is attempted to run, but only XML changes are made, the GitHub action can fail

### DIFF
--- a/src/.github/workflows/{% if github_actions and github_actions_ci_branches %}ci.yml{% endif %}.jinja
+++ b/src/.github/workflows/{% if github_actions and github_actions_ci_branches %}ci.yml{% endif %}.jinja
@@ -102,6 +102,7 @@ jobs:
 
       - name: Post coverage report
         uses: orgoro/coverage@v3.1
+        if: ${{ hashFiles('odoo/auto/coverage.xml') != '' }}
         with:
             coverageFile: odoo/auto/coverage.xml
             token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/tasks_downstream.py
+++ b/src/tasks_downstream.py
@@ -427,6 +427,10 @@ def test_coverage_report(c, format=None):
     if format is None:
         format = "html"
 
+    if not (PROJECT_ROOT / "odoo" / "auto" / ".coverage").exists():
+        _logger.warning("Coverage input file does not exist, skipping")
+        return
+
     FORMAT_TO_COMMAND = {
         "html": "html -d /opt/odoo/auto/coverage",
         "xml": "xml -o /opt/odoo/auto/coverage.xml",


### PR DESCRIPTION
## Description

If coverage is attempted to run, but only XML changes are made, the GitHub action can fail.

This is untested.

Associated risk level low

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update