### PR TITLE
GH115472 - Add google_auth

### DIFF
--- a/src/odoo/custom/dependencies/pip.txt.jinja
+++ b/src/odoo/custom/dependencies/pip.txt.jinja
@@ -6,3 +6,4 @@ pathlib
 {% endif -%}
 inotify
 coverage
+google_auth


### PR DESCRIPTION
This module is now required by the Social Marketing app, so should be installed by default

Fixes GH115472

Associated risk level low

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
