### PR TITLE
feat: use haproxy to both proxy to the odoo container and also the whitelisted hosts in a single combined container

### DIFF
--- a/_macros.jinja
+++ b/_macros.jinja
@@ -7,3 +7,17 @@
 {%- macro version_minor(odoo_version) %}
     {{- "%.1f"|format(odoo_version) }}
 {%- endmacro %}
+
+{# Odoo whitelisted hosts based on odoo_version #}
+{%- macro whitelisted_hosts(odoo_version) %}
+    {%- set whitelisted_hosts = [
+      "fonts.googleapis.com",
+      "fonts.gstatic.com",
+      "www.googleapis.com",
+      "www.gravatar.com",
+    ] -%}
+    {% if odoo_version <= 15 -%}
+    {% set whitelisted_hosts = ["cdnjs.cloudflare.com"] + whitelisted_hosts -%}
+    {% endif -%}
+    {{- whitelisted_hosts | join(",") }}
+{%- endmacro %}

--- a/src/devel.yaml.jinja
+++ b/src/devel.yaml.jinja
@@ -5,7 +5,6 @@ services:
   # When you hit it on
   ha_proxy:
     image: haproxy:lts-alpine
-    restart: unless-stopped
     stop_grace_period: 0s
     networks:
       default:
@@ -25,6 +24,8 @@ services:
     {%- if odoo_oci_image %}
     image: {{ odoo_oci_image }}:{{ macros.version_minor(odoo_version) }}
     {%- endif %}
+    stop_grace_period: 0s
+    restart: unless-stopped
     build:
       context: ./odoo
       args:
@@ -108,6 +109,8 @@ services:
 
   smtp:
     image: axllent/mailpit
+    stop_grace_period: 0s
+    restart: unless-stopped
     networks: *public
     ports:
       - "{{ macros.version_major(odoo_version) }}025:8025"

--- a/src/devel.yaml.jinja
+++ b/src/devel.yaml.jinja
@@ -1,30 +1,25 @@
 {%- import "_macros.jinja" as macros -%}
-{% set whitelisted_hosts = [
-  "fonts.googleapis.com",
-  "fonts.gstatic.com",
-  "www.googleapis.com",
-  "www.gravatar.com",
-] -%}
-{% if odoo_version <= 15 -%}
-{% set whitelisted_hosts = "cdnjs.cloudflare.com" + whitelisted_hosts -%}
-{% endif -%}
 
 services:
-  odoo_proxy:
-    image: ghcr.io/tecnativa/docker-whitelist:latest
+  # ha_proxy replaces odoo_proxy and the various whitelist_proxy and combines them
+  # When you hit it on
+  ha_proxy:
+    image: haproxy:lts-alpine
+    restart: unless-stopped
     stop_grace_period: 0s
-    depends_on:
-      - odoo
-    networks: &public
+    networks:
       default:
+        aliases:
+          {%- for whitelisted_host in macros.whitelisted_hosts(odoo_version).split(",") %}
+          - {{ whitelisted_host|tojson }}
+          {%- endfor %}
       public:
     ports:
       - "{{ macros.version_major(odoo_version) }}899:6899"
       - "{{ macros.version_major(odoo_version) }}069:8069"
       - "{{ macros.version_major(odoo_version) }}072:8072"
-    environment:
-      PORT: "6899 8069 8072"
-      TARGET: odoo
+    volumes:
+      - ./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro
 
   odoo:
     {%- if odoo_oci_image %}
@@ -69,10 +64,8 @@ services:
       - ./odoo/auto:/opt/odoo/auto:rw,z
     depends_on:
       - db
-      {% for host in whitelisted_hosts -%}
-      - proxy_{{ host|replace(".", "_") }}
-      {% endfor -%}
       - smtp
+      - ha_proxy
     command:
       - odoo
       - --limit-memory-soft=0
@@ -104,7 +97,9 @@ services:
       #   - https://www.postgresql.org/docs/16/indexes-types.html#INDEXES-TYPES-BTREE
       POSTGRES_INITDB_ARGS: "--locale=C --encoding=UTF8"
       POSTGRES_PASSWORD: odoopassword
-    networks: *public
+    networks: &public
+      default:
+      public:
     ports:
       - "{{ macros.version_major(odoo_version) }}432:5432"
     volumes:
@@ -117,20 +112,6 @@ services:
     ports:
       - "{{ macros.version_major(odoo_version) }}025:8025"
 
-  # Whitelist outgoing traffic for tests, reports, etc.
-{%- for host in whitelisted_hosts %}
-  proxy_{{ host|replace(".", "_") }}:
-    image: ghcr.io/tecnativa/docker-whitelist:latest
-    stop_grace_period: 0s
-    networks:
-      default:
-        aliases:
-          - {{ host }}
-      public:
-    environment:
-      TARGET: {{ host }}
-      PRE_RESOLVE: 1
-{% endfor %}
 networks:
   default:
     internal: true

--- a/src/haproxy.cfg.jinja
+++ b/src/haproxy.cfg.jinja
@@ -1,0 +1,61 @@
+{%- import "_macros.jinja" as macros -%}
+defaults
+  mode tcp
+  timeout client 10s
+  timeout connect 5s
+  timeout server 10s
+  timeout http-request 10s
+
+frontend odoo_web
+  bind 0.0.0.0:8069
+  default_backend odoo_web
+
+frontend odoo_longpolling
+  bind 0.0.0.0:8072
+  default_backend odoo_longpolling
+
+frontend odoo_pudb
+  bind 0.0.0.0:6899
+  default_backend odoo_pudb
+
+backend odoo_web
+  server server1 odoo:8069
+
+backend odoo_longpolling
+  server server1 odoo:8072
+
+backend odoo_pudb
+  server server1 odoo:6899
+
+resolvers the_internet
+  nameserver google 8.8.8.8:53
+  hold other           30s
+  hold refused         30s
+  hold nx              30s
+  hold timeout         30s
+  hold valid           1800s
+  hold obsolete        30s
+
+### Whitelisting
+
+frontend whitelist
+  bind *:443
+  option tcplog
+  mode tcp
+
+  tcp-request inspect-delay 5s
+  tcp-request content accept if { req_ssl_hello_type 1 }
+
+  {%- for whitelisted_host in macros.whitelisted_hosts(odoo_version).split(",") %}
+  acl is_{{ whitelisted_host | replace(".", "_") }} req_ssl_sni -i {{ whitelisted_host }}
+  {%- endfor %}
+
+  {%- for whitelisted_host in macros.whitelisted_hosts(odoo_version).split(",") %}
+  use_backend backend_{{ whitelisted_host | replace(".", "_") }} if is_{{ whitelisted_host | replace(".", "_") }}
+  {%- endfor %}
+
+{%- for whitelisted_host in  macros.whitelisted_hosts(odoo_version).split(",") %}
+backend backend_{{ whitelisted_host | replace(".", "_") }}
+    mode tcp
+    server server1 {{ whitelisted_host }} resolvers the_internet resolve-prefer ipv4
+{%- endfor %}


### PR DESCRIPTION
## Description

The more containers you add the slower things stop and start. When using debugpy this can be tedious if you need to restart the world. 

This PR reduces the average stopping time down to 1-2s on my desktop. The majority is now PostgreSQL cleanly shutting down.

This PR achieves this by:
  - reducing the number of containers down to 4 by merging the `odoo_proxy` container and all `whitelist` containers into one, by using haproxy in TCP mode
  - For the whitelisting we make the critical assumption that anything that needs to talk uses HTTPS and is able to use SNI. This allows us to configure haproxy, and smash every whitelist/proxy container into 1

Before and after on a real customer project. The database and Odoo was warmed in the same way, before stopping in both cases, but no active crons, etc. were running.

```
✦ ❯ time invoke stop
[+] Stopping 10/10
 ✔ Container REDACTED-odoo-odoo_proxy-1                  Stopped                                                0.8s
 ✔ Container REDACTED-odoo-odoo-1                        Stopped                                                1.0s
 ✔ Container REDACTED-odoo-proxy_cdnjs_cloudflare_com-1  Stopped                                                3.0s
 ✔ Container REDACTED-odoo-proxy_fonts_googleapis_com-1  Stopped                                                3.6s
 ✔ Container REDACTED-odoo-proxy_www_gravatar_com-1      Stopped                                                3.1s
 ✔ Container REDACTED-odoo-proxy_www_googleapis_com-1    Stopped                                                3.2s
 ✔ Container REDACTED-odoo-proxy_fonts_gstatic_com-1     Stopped                                                3.7s
 ✔ Container REDACTED-odoo-smtp-1                        Stopped                                                3.4s
 ✔ Container REDACTED-odoo-proxy_www_google_com-1        Stopped                                                4.0s
 ✔ Container REDACTED-odoo-db-1                          Stopped                                                3.8s

real    0m6.041s
user    0m0.132s
sys     0m0.058s
```

After

```
✦ ❯ time invoke stop
[+] Stopping 4/4
 ✔ Container workstories-odoo_odoo_1      Stopped                                                                                                                                 0.3s
 ✔ Container workstories-odoo_db_1        Stopped                                                                                                                                 1.7s
 ✔ Container workstories-odoo_smtp_1      Stopped                                                                                                                                 1.3s
 ✔ Container workstories-odoo_ha_proxy_1  Stopped                                                                                                                                 1.8s

real    0m2.327s
user    0m0.087s
sys     0m0.055s
```

Associated risk level medium

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update