### PR TITLE
Add XML formatting to match pre-commit

### DIFF
--- a/src/.vscode/settings.json
+++ b/src/.vscode/settings.json
@@ -41,5 +41,9 @@
   "python.testing.pytestEnabled": true,
   "python.testing.unittestEnabled": false,
   "restructuredtext.confPath": "",
-  "search.followSymlinks": false
+  "search.followSymlinks": false,
+  "xml.format.spaceBeforeEmptyCloseTag": false,
+  "xml.format.preserveAttributeLineBreaks": false,
+  "xml.format.splitAttributes": "preserve",
+  "xml.format.maxLineWidth": 0
 }


### PR DESCRIPTION
Pre-commit and VSCode XML formatting were in conflict, so format on save would change the format and then pre-commit would change it back. This hopefully fixes that

Associated risk level low

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
