### PR TITLE
Add kube command

### DIFF
--- a/guides/provision.sh
+++ b/guides/provision.sh
@@ -168,7 +168,7 @@ install_pipx() {
   ~/.local/bin/pipx install copier
   ~/.local/bin/pipx install invoke
   ~/.local/bin/pipx install pre-commit
-  ~/.local/bin/pipx install inquirer
+  python3 -m pip install --user inquirer
   
   grep -qxF 'export PATH=$PATH:~/.local/bin/' ~/.bashrc || echo 'export PATH=$PATH:~/.local/bin/' >> ~/.bashrc
 

--- a/guides/provision.sh
+++ b/guides/provision.sh
@@ -168,6 +168,7 @@ install_pipx() {
   ~/.local/bin/pipx install copier
   ~/.local/bin/pipx install invoke
   ~/.local/bin/pipx install pre-commit
+  ~/.local/bin/pipx install inquirer
   
   grep -qxF 'export PATH=$PATH:~/.local/bin/' ~/.bashrc || echo 'export PATH=$PATH:~/.local/bin/' >> ~/.bashrc
 

--- a/guides/provision.sh
+++ b/guides/provision.sh
@@ -168,7 +168,6 @@ install_pipx() {
   ~/.local/bin/pipx install copier
   ~/.local/bin/pipx install invoke
   ~/.local/bin/pipx install pre-commit
-  python3 -m pip install --user inquirer
   
   grep -qxF 'export PATH=$PATH:~/.local/bin/' ~/.bashrc || echo 'export PATH=$PATH:~/.local/bin/' >> ~/.bashrc
 

--- a/src/tasks_downstream.py
+++ b/src/tasks_downstream.py
@@ -775,15 +775,15 @@ def kube(c, command, namespace="none"):
 
     yaml_exists = os.path.exists(PROJECT_ROOT / ".glo.yaml")
 
-    # Fetch the namespace from a project.yaml file
+    # Fetch the namespace from a .glo.yaml file
     if namespace == "none":
         if yaml_exists:
-            namespace = yaml.safe_load((PROJECT_ROOT / "project.yaml").read_text())[
+            namespace = yaml.safe_load((PROJECT_ROOT / ".glo.yaml").read_text())[
                 "namespace"
             ]
         else:
             _logger.error(
-                "Namespace not provided or found in project.yaml file. "
+                "Namespace not provided or found in .glo.yaml file. "
                 "Please provide a namespace.\n"
                 "Use: invoke kube {command} -n MyNamespace"
             )

--- a/src/tasks_downstream.py
+++ b/src/tasks_downstream.py
@@ -792,7 +792,7 @@ def kube(c, command, namespace="none"):
     # If the yaml file does not exist, create one with the namespace provided
     if not yaml_exists:
         namespace = namespace.strip()
-        with open(PROJECT_ROOT / "project.yaml", "w") as f:
+        with open(PROJECT_ROOT / ".glo.yaml", "w") as f:
             f.write(f"namespace: {namespace}")
 
     if command == "shell":

--- a/src/tasks_downstream.py
+++ b/src/tasks_downstream.py
@@ -778,7 +778,7 @@ def check_make_yaml(filename):
         "Options: ['shell', 'logs', 'bash', 'upgradelog', 'pgactivity', 'removens']",
     }
 )
-def kube(c, command, namespace="none", db="none"):
+def kube(c, command, namespace=None):
     """Run a kubectl command in the provided namespace."""
     namespace = namespace.strip()
     command = command.strip().lower()
@@ -790,7 +790,7 @@ def kube(c, command, namespace="none", db="none"):
     )
 
     # Fetch the namespace from a .glo.yaml file
-    if namespace == "none":
+    if namespace is None:
         if len(namespaces) == 1:
             namespace = namespaces[0]
         elif len(namespaces) > 1:
@@ -831,8 +831,6 @@ def kube(c, command, namespace="none", db="none"):
             f"kubectl exec deployment/odoo-web -it -n {namespace}"
             " -- odoo shell --no-http"
         )
-        if db != "none":
-            cmd += f" -d {db}"
     elif command == "logs":
         cmd = f"kubectl logs -f deployment/odoo-web -n {namespace} --all-containers"
     elif command == "bash":

--- a/src/tasks_downstream.py
+++ b/src/tasks_downstream.py
@@ -773,7 +773,7 @@ def down(c, purge=False):
 def kube(c, command, namespace="none"):
     """Run a kubectl command in the provided namespace."""
 
-    yaml_exists = os.path.exists(PROJECT_ROOT / "project.yaml")
+    yaml_exists = os.path.exists(PROJECT_ROOT / ".glo.yaml")
 
     # Fetch the namespace from a project.yaml file
     if namespace == "none":

--- a/src/tasks_downstream.py
+++ b/src/tasks_downstream.py
@@ -765,6 +765,24 @@ def down(c, purge=False):
 
 
 @task()
+def kube(c, command, namespace="default"):
+    """Run a kubectl command in the provided namespace."""
+    if command == "shell":
+        cmd = "kubectl exec deployment/odoo-web -it -n {namespace} -- odoo shell --no-http"
+    elif command == "logs":
+        cmd = "kubectl logs -f deployment/odoo-web -n {namespace} --all-containers"
+    elif command == "bash":
+        cmd = "kubectl exec deployment/odoo-web -it -n {namespace} -- bash"
+    elif command == "upgradelog":
+        cmd = "kubectl logs -f job/odoo-upgrade -n {namespace}"
+    elif command == "pgactivity":
+        cmd = "kubectl exec deployment/odoo-web -it -n {namespace} -- pg_activity"
+    else:
+        raise exceptions.PlatformError(f"Command {command} not found.")
+    c.run(cmd, pty=True)
+
+
+@task()
 def preparedb(c, database=False):
     """
     Run the `preparedb` script inside the container which will set the following

--- a/src/tasks_downstream.py
+++ b/src/tasks_downstream.py
@@ -764,6 +764,14 @@ def down(c, purge=False):
         c.run(cmd, pty=True)
 
 
+def check_make_yaml(filename):
+    yaml_exists = os.path.exists(PROJECT_ROOT / filename)
+    if not yaml_exists:
+        # Create empty yaml file
+        with open(PROJECT_ROOT / filename, "w") as f:
+            f.write("namespaces: []\n")
+
+
 @task(
     help={
         "command": "Command to run in the container. "


### PR DESCRIPTION
New invoke command to handle kubectl commands so we don't need to keep referring to the cheatsheet

It will read the customers namespace from a .glo.yaml file in the project root, or, if one doesn't exist, you can provide one using '-n {namespace}' and it will create the .glo..yaml for you. If you provide a new namespace, it will be added to a list that you can choose from next time you run the command. You can use invoke kube removens -n {namespace} to remove one you added by mistake, or is no longer valid.

Example Commands:
`invoke kube shell -n dw -d dw` will create a .glo.yaml file containing the namespace dw, if it doesn't exist, then connect to their shell, connected to the dw database. -n and -d are optional where a .glo.yaml file already exists.

`invoke kube shell` will connect to the namespace stored in .glo.yaml and the default database. If multiple namespaces exist in .glo.yaml you will be asked to pick one.

Associated risk level low

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
