### PR TITLE
feat: add jingtrang to pip deps for odoo >= 13

### DIFF
--- a/src/odoo/custom/dependencies/pip.txt.jinja
+++ b/src/odoo/custom/dependencies/pip.txt.jinja
@@ -7,3 +7,6 @@ pathlib
 inotify
 coverage
 google_auth
+{% if odoo_version >= 13.0 -%}
+jingtrang
+{% endif -%}


### PR DESCRIPTION
## Description

jingtrang provides better output for XML errors:

See https://github.com/odoo/odoo/commit/16cd987a53bcc7c29af28b58bec8d8bf6cc1b9d7

Before (without Jingtrang):
`ERROR:RELAXNGV:RELAXNG_ERR_EXTRACONTENT: Element odoo has extra content: data`

After (with Jingtrang):
`error: text not allowed here; expected the element end-tag or element "field"`

I would argue that this would be better suited in the upstream Dockerfile for each Odoo version... however, see #61