### PR TITLE
[FIX] Error in kube command

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -26,6 +26,7 @@
 /doodba.*.code-workspace
 /src
 *.rej
+.glo.yaml
 
 # Project-specific docker configurations
 /.docker/

--- a/src/tasks_downstream.py
+++ b/src/tasks_downstream.py
@@ -780,7 +780,7 @@ def check_make_yaml(filename):
 )
 def kube(c, command, namespace=None):
     """Run a kubectl command in the provided namespace."""
-    namespace = namespace.strip()
+    namespace = namespace.strip() if namespace else None
     command = command.strip().lower()
     filename = ".glo.yaml"
     check_make_yaml(filename)


### PR DESCRIPTION
You can now use `invoke kube [command]` without specifying a namespace if one has already been used in this project.

If multiple namespaces have been used before it will prompt which to use

You can add a namespace at any time with:
`invoke kube [command] -n {namespace}`

Once used once, you don't need to use -n for future commands

You can remove a namespace using:
`invoke kube removens -n {namespace}`


Fixes current error when using invoke kube

**Dependencies:**
- N/A

**ARL (Associated Risk Level):**
- [x] Low
- [ ] Medium
- [ ] High

**Type of change:**
- [ ] Forwardport / Backport
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

